### PR TITLE
Core fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Obsidian's Wyrd
+
+And amazing. So I'm making this theme weird, too.
+
+Wyrd is a purple-hued, low-contrast theme for [Obsidian.md](https://obsidian.md).
+
+## Features
+
+- Visual balance between light and dark modes!
+- Custom font selection `@import`ed through Google Fonts!
+- All fonts scale with the current `--editor-font-size`!
+  - Including headings (!!)
+
+### Planned
+
+- [ ] Snippet to make font selection locally available for offline use
+  - Necessary, as some fonts contain 50+ variations
+- [ ] Style Settings compatability
+- [ ] 

--- a/Wyrd.css
+++ b/Wyrd.css
@@ -1,5 +1,4 @@
 /**
-  Some notes on this theme:
   - 
  */
 
@@ -16,9 +15,9 @@
   --color-grey-01: hsl(270, 10%, 15%);
   --color-grey-02: hsl(270, 10%, 17.5%);
   --color-grey-03: hsl(270, 10%, 20%);
-  --color-grey-04: hsl(270, 8%, 30%); /* text */
+  --color-grey-04: hsl(270, 8%, 35%); /* text */
   --color-grey-05: hsl(270, 8%, 50%);
-  --color-grey-06: hsl(270, 13%, 70%);
+  --color-grey-06: hsl(270, 13%, 65%);
   --color-grey-07: hsl(270, 10%, 72.5%); /* light mode */
   --color-grey-08: hsl(270, 10%, 75%);
   --color-grey-09: hsl(270, 10%, 77.5%);

--- a/Wyrd.css
+++ b/Wyrd.css
@@ -3,10 +3,29 @@
  */
 
 /**
-  Color palette
+  Font imports
+ */
+/* Preview: Neucha */
+@import url('https://fonts.googleapis.com/css2?family=Neucha&display=swap');
+/* Edit:  */
+/* Monospace: Space Mono — NOT SELECTED FOR LIGATURES */
+@import url('https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap');
+/* Headings: Birthstone */
+@import url('https://fonts.googleapis.com/css2?family=Birthstone&display=swap');
+/**
+  Core Defaults
  */
 :root {
-  /* Colors */
+  /* Fonts */
+  --default-font: Neucha, Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif;
+  --mermaid-font: var(--default-font);
+  --reveal-font: var(--default-font);
+  --font-monospace: 'Space Mono', 'Source Code Pro', monospace;
+  --font-heading: Birthstone;
+  /* Only active within Publish spaces; body styling overrides this within Obsidian */
+  --editor-font-size: 16px;
+
+  /* Color Palette */
   --color-blacker-hsl: hsl(270, 10%, 5%);
   --color-blacker-hsl: 270, 10%, 5%;
   --color-black-hsl: hsl(270, 10%, 10%);
@@ -115,4 +134,58 @@ Light Mode defaults
   --scrollbar-bg: hsla(var(--scrollbar-hsl), 0.05);
   --scrollbar-thumb-bg: hsla(var(--scrollbar-hsl), 0.1);
   --highlight-mix-blend-mode: lighten;
+}
+/* Preview */
+.markdown-preview-view {
+  font-size: var(--editor-font-size);
+}
+/* Preview — Headings */
+.markdown-preview-view h1,
+.markdown-preview-view h2,
+.markdown-preview-view h3,
+.markdown-preview-view h4,
+.markdown-preview-view h5,
+.markdown-preview-view h6 {
+  font-family: var(--font-heading);
+}
+.markdown-preview-view h1 {
+  font-size: calc(var(--editor-font-size) * 2.5);
+}
+.markdown-preview-view h2 {
+  font-size: calc(var(--editor-font-size) * 2.1);
+}
+.markdown-preview-view h3 {
+  font-size: calc(var(--editor-font-size) * 1.8);
+}
+.markdown-preview-view h4 {
+  font-size: calc(var(--editor-font-size) * 1.55);
+}
+.markdown-preview-view h5 {
+  font-size: calc(var(--editor-font-size) * 1.35);
+}
+.markdown-preview-view h6 {
+  font-size: calc(var(--editor-font-size) * 1.2);
+}
+
+/* Edit — Headings */
+.cm-s-obsidian .HyperMD-header {
+  font-family: var(--font-heading) !important;
+}
+.cm-s-obsidian .HyperMD-header-1 {
+  font-size: calc(var(--editor-font-size) * 1.6);
+}
+.cm-s-obsidian .HyperMD-header-2 {
+  font-size: calc(var(--editor-font-size) * 1.5);
+}
+.cm-s-obsidian .HyperMD-header-3 {
+  font-size: calc(var(--editor-font-size) * 1.4);
+}
+.cm-s-obsidian .HyperMD-header-4 {
+  font-size: calc(var(--editor-font-size) * 1.3);
+}
+.cm-s-obsidian .HyperMD-header-5 {
+  font-size: calc(var(--editor-font-size) * 1.2);
+}
+.cm-s-obsidian .HyperMD-header-6 {
+  font-size: calc(var(--editor-font-size) * 1.1);
 }


### PR DESCRIPTION
Basics are now covered:

- Core fonts selected:
  - Editor and preview mode: [Neucha](https://fonts.google.com/specimen/Neucha)
  - Monospace: [Space Mono](https://fonts.google.com/specimen/Space+Mono)
  - Headings: [Birthstone](https://fonts.google.com/specimen/Birthstone)
- Body and heading font sizes (preview & edit modes) scale with the current `--editor-font-size` within Obsidian
  - `--editor-font-size` is also set in `:root` for Publish environments, as the variable won't exist otherwise