### PR TITLE
v0.3.0: Live Preview, Print, File Explorer, Graph View and more!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+desktop.files.json

--- a/obsidian.css
+++ b/obsidian.css
@@ -648,6 +648,16 @@ ol ol ol ol ol ol li::marker {
   color: var(--color-cyan-desat);
 }
 /* 4.3.3 Preview — Task Lists */
+.markdown-preview-view ul > li.task-list-item.is-checked,
+.markdown-preview-view ul > li > ul > li.task-list-item.is-checked,
+.markdown-preview-view ul > li.task-list-item > ul > li.task-list-item.is-checked {
+  text-decoration: none;
+  color: var(--text-faint);
+}
+.markdown-preview-view ul > li.task-list-item.is-checked > ul > li,
+.markdown-preview-view.mod-cm6 ul > li.task-list-item.is-checked > ul > li {
+  color: var(--text-normal);
+}
 /* 4.4 Preview — Links */
 /* 4.4.1 Preview — Links — Internal */
 .markdown-preview-view .internal-link {
@@ -849,6 +859,39 @@ ol ol ol ol ol ol li::marker {
               0 -1px 4px var(--color-blue) inset,
               0 -1px 2px var(--shadow-primary),
               0 -1px 4px var(--shadow-primary);
+}
+/* Preview, Publish — Embeds */
+.markdown-embed {
+  border-top: none;
+  border-bottom: none;
+}
+/* Preview, Publish — Popovers */
+/* .popover {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  overflow: visible;
+} */
+.popover,
+.popover.hover-popover {
+  background-color: var(--background-secondary);
+  border-left: 1px solid var(--shadow-primary);
+  border-radius: 1.5rem;
+  border-right: 1px solid var(--shadow-primary);
+  box-shadow: 0 -1px 2px var(--shadow-primary),
+              0 -1px 4px var(--shadow-primary),
+              0 -1px 8px var(--shadow-primary),
+              0 -1px 16px var(--shadow-primary);
+}
+.popover .markdown-preview-view,
+.popover.hover-popover .markdown-preview-view {
+  background-color: var(--background-primary);
+  border-radius: 1.5rem;
+}
+.popover.hover-popover .thought {
+  border-bottom: 1px solid var(--color-purple-3);
+  border-left: 3px solid var(--color-purple-3);
+  border-top: 1px solid var(--color-purple-3);
 }
 /* Publish */
 /* Publish — Header */
@@ -1363,6 +1406,53 @@ span.cm-formatting-quote-6,
 .HyperMD-list-line-6 .list-bullet::before,
 .HyperMD-list-line.HyperMD-list-line-6 .cm-formatting-list {
   color: var(--color-cyan-desat);
+}
+.markdown-source-view.mod-cm6 .task-list-item-checkbox[data-task] {
+  border-radius: 5px;
+  -webkit-appearance: none;
+  filter: none;
+  height: calc(var(--editor-font-size) * 0.8);
+  position: relative;
+  width: calc(var(--editor-font-size) * 0.8);
+}
+.markdown-source-view.mod-cm6 .HyperMD-task-line[data-task] .task-list-item-checkbox {
+  background: var(--background-primary);
+  border: 1.5px solid var(--color-magic-gold);
+  vertical-align: text-top;
+}
+.markdown-source-view.mod-cm6 .HyperMD-task-line.HyperMD-list-line-1[data-task='x'] .task-list-item-checkbox,
+.markdown-source-view.mod-cm6 .HyperMD-task-line.HyperMD-list-line-1:not([data-task=' ']) .task-list-item-checkbox {
+  background: var(--color-purple-3);
+}
+.markdown-source-view.mod-cm6 .HyperMD-task-line.HyperMD-list-line-2[data-task='x'] .task-list-item-checkbox,
+.markdown-source-view.mod-cm6 .HyperMD-task-line.HyperMD-list-line-2:not([data-task=' ']) .task-list-item-checkbox {
+  background: var(--color-hot-pink);
+}
+.markdown-source-view.mod-cm6 .HyperMD-task-line.HyperMD-list-line-3[data-task='x'] .task-list-item-checkbox,
+.markdown-source-view.mod-cm6 .HyperMD-task-line.HyperMD-list-line-3:not([data-task=' ']) .task-list-item-checkbox {
+  background: var(--color-shadowy-gold);
+}
+.markdown-source-view.mod-cm6 .HyperMD-task-line.HyperMD-list-line-4[data-task='x'] .task-list-item-checkbox,
+.markdown-source-view.mod-cm6 .HyperMD-task-line.HyperMD-list-line-4:not([data-task=' ']) .task-list-item-checkbox {
+  background: var(--color-green);
+}
+.markdown-source-view.mod-cm6 .HyperMD-task-line.HyperMD-list-line-5[data-task='x'] .task-list-item-checkbox,
+.markdown-source-view.mod-cm6 .HyperMD-task-line.HyperMD-list-line-5:not([data-task=' ']) .task-list-item-checkbox {
+  background: var(--color-teal);
+}
+.markdown-source-view.mod-cm6 .HyperMD-task-line.HyperMD-list-line-6[data-task='x'] .task-list-item-checkbox,
+.markdown-source-view.mod-cm6 .HyperMD-task-line.HyperMD-list-line-6:not([data-task=' ']) .task-list-item-checkbox {
+  background: var(--color-cyan-desat);
+}
+.markdown-source-view.mod-cm6 .HyperMD-task-line[data-task]:not([data-task=" "]) {
+  text-decoration: none;
+  color: var(--text-faint);
+}
+.markdown-source-view.mod-cm6 .HyperMD-list-line.HyperMD-task-line[data-task='-'] {
+  color: var(--text-strike);
+}
+.markdown-source-view.mod-cm6 .HyperMD-list-line.HyperMD-task-line[data-task='-'] .task-list-item-checkbox {
+  background: var(--text-strike);
 }
 /* Edit — Links */
 .markdown-source-view.mod-cm6.is-live-preview .cm-line .cm-hmd-internal-link .cm-underline,

--- a/obsidian.css
+++ b/obsidian.css
@@ -922,6 +922,74 @@ ol ol ol ol ol ol li::marker {
   go at the top of the file!
  */
 
+/* Print */
+@media print {
+  :root {
+    --default-font: 'Kalam';
+  }
+  .markdown-preview-view h1:before,
+  .markdown-preview-view h2:before,
+  .markdown-preview-view h3:before,
+  .markdown-preview-view h4:before,
+  .markdown-preview-view h5:before,
+  .markdown-preview-view h6:before {
+    background: none;
+    border-width: 1px;
+    border-style: solid;
+    border-right: 0;
+  }
+  .markdown-preview-view h1 {
+    color: var(--color-purple-3);
+    -webkit-text-fill-color: unset;
+    -webkit-text-stroke: unset;
+  }
+  .markdown-preview-view h1:before {
+    border-color: var(--color-purple-3);
+  }
+  .markdown-preview-view h2 {
+    color: var(--color-hot-pink);
+    -webkit-text-fill-color: unset;
+    -webkit-text-stroke: unset;
+  }
+  .markdown-preview-view h2:before {
+    border-color: var(--color-hot-pink);
+  }
+  .markdown-preview-view h3 {
+    color: var(--color-shadowy-gold);
+    -webkit-text-fill-color: unset;
+    -webkit-text-stroke: unset;
+  }
+  .markdown-preview-view h3:before {
+    border-color: var(--color-shadowy-gold);
+  }
+  .markdown-preview-view h4 {
+    color: var(--color-green);
+    -webkit-text-fill-color: unset;
+    -webkit-text-stroke: unset;
+  }
+  .markdown-preview-view h4:before {
+    border-color: var(--color-green);
+  }
+  .markdown-preview-view h5 {
+    color: var(--color-teal);
+    -webkit-text-fill-color: unset;
+    -webkit-text-stroke: unset;
+  }
+  .markdown-preview-view h5:before {
+    border-color: var(--color-teal);
+  }
+  .markdown-preview-view h6 {
+    color: var(--color-purple-3);
+    -webkit-text-fill-color: unset;
+    -webkit-text-stroke: unset;
+  }
+  .markdown-preview-view h6:before {
+    border-color: var(--color-cyan-desat);
+  }
+  .markdown-preview-view blockquote {
+    color: var(--color-grey-00);
+  }
+}
 /* 9 Settings */
 button,
 select,

--- a/obsidian.css
+++ b/obsidian.css
@@ -1381,6 +1381,9 @@ span.cm-formatting-quote-6,
 .markdown-source-view.mod-cm6 .external-link {
   display: none;
 }
+.markdown-source-view.mod-cm6 .markdown-embed .external-link {
+  display: inline;
+}
 .cm-s-obsidian span.cm-url,
 .cm-s-obsidian span.cm-link,
 .cm-s-obsidian span.cm-footref,
@@ -1502,6 +1505,7 @@ span.cm-formatting-quote-6,
 .markdown-source-view.mod-cm6 .cm-comment,
 .cm-s-obsidian span.cm-comment {
   color: var(--text-muted);
+
 }
 
 /* 11 Animations */

--- a/obsidian.css
+++ b/obsidian.css
@@ -132,7 +132,7 @@
   --text-on-accent: var(--text-normal);
   --scrollbar-hsl: var(--color-deep-purple-hsl);
   --text-strike: var(--color-grey-02);
-  --shadow-primary: var(--color-grey-00);
+  --shadow-primary: var(--color-grey-01);
 }
 
 /**
@@ -150,7 +150,7 @@
   --text-on-accent: var(--text-faint);
   --scrollbar-hsl: var(--color-pale-purple-hsl);
   --text-strike: var(--color-grey-08);
-  --shadow-primary: var(--color-grey-06);
+  --shadow-primary: var(--color-grey-05);
 }
 
 /**

--- a/obsidian.css
+++ b/obsidian.css
@@ -819,59 +819,69 @@ ol ol ol ol ol ol li::marker {
   border: none;
   border-left: 2px solid var(--color-shadowy-gold);
   border-right: 2.5px solid var(--color-shadowy-gold);
-  border-radius: 0px;
+  border-radius: 0;
   transition: var(--transition-duration-normal) border-radius, background, box-shadow ease-in-out;
 }
-.nav-files-container .tree-item:hover,
-.nav-files-container .nav-file-title:hover {
-  border-radius: 0.5rem 0.5rem;
-  border-left: 2px solid var(--color-shadowy-gold);
-  border-right: 2.5px solid var(--color-shadowy-gold);
+.tree-item:hover,
+.nav-file-title:hover,
+.nav-folder-title:hover {
+  border-radius: 0.5rem;
+}
+.nav-folder-children > div:first-child:not() {
+  /* removes the small gap between folders and the files within them */
+  display: none;
+}
+.tree-item:hover {
+  box-shadow: 0 -1px 1px var(--color-hot-pink) inset,
+              0 -1px 2px var(--color-hot-pink) inset,
+              0 -1px 4px var(--color-hot-pink) inset;
+}
+.nav-file-title:hover {
   box-shadow: 0 -1px 1px var(--color-green) inset,
               0 -1px 2px var(--color-green) inset,
-              0 -1px 4px var(--color-green) inset,
-              0 -1px 2px var(--shadow-primary),
-              0 -1px 4px var(--shadow-primary);
+              0 -1px 4px var(--color-green) inset;
 }
-.nav-files-container .nav-folder-title:hover {
-  border-radius: 0.5rem 0.5rem;
-  border-left: 2px solid var(--color-shadowy-gold);
-  border-right: 2.5px solid var(--color-shadowy-gold);
+.nav-folder:not(.mod-root):not(.is-collapsed) .nav-folder-title {
+  /* restyle slightly for expanded folders */
+  border-radius: 0.5rem;
+  box-shadow: 0 -1px 1px var(--color-cyan) inset,
+              0 -1px 2px var(--color-teal) inset,
+              0 -1px 4px var(--color-teal) inset;
+  transition: var(--transition-duration-normal) border-radius ease-in-out;
+}
+.nav-folder:not(.mod-root):not(.is-collapsed) .nav-folder-title:hover {
+  border-radius: 0.75rem;
+}
+.nav-folder.is-collapsed .nav-folder-title:hover {
   box-shadow: 0 -1px 1px var(--color-teal) inset,
               0 -1px 2px var(--color-teal) inset,
-              0 -1px 4px var(--color-teal) inset,
-              0 -1px 2px var(--shadow-primary),
-              0 -1px 4px var(--shadow-primary);
+              0 -1px 4px var(--color-teal) inset;
 }
-.nav-files-container .tree-item.mod-active,
-.nav-files-container .nav-file-title.is-active {
-  border-radius: 0.5rem 0.5rem;
+.tree-item.mod-active,
+.nav-file-title.is-active {
   border-left: 2px solid var(--color-magic-gold);
+  border-radius: 0.5rem;
   border-right: 2.5px solid var(--color-magic-gold);
   box-shadow: 0 -1px 1px var(--color-purple-3) inset,
               0 -1px 2px var(--color-purple-3) inset,
-              0 -1px 4px var(--color-purple-3) inset,
-              0 -1px 2px var(--shadow-primary),
-              0 -1px 4px var(--shadow-primary);
+              0 -1px 4px var(--color-purple-3) inset;
   transition: var(--transition-duration-normal) border-radius ease-in-out;
 }
-.nav-files-container .tree-item.mod-active:hover,
-.nav-files-container .nav-file-title.is-active:hover {
-  border-radius: 0.75rem 0.75rem;
+.tree-item.mod-active:hover,
+.nav-file-title.is-active:hover {
+  border-radius: 0.75rem;
 }
 /* Preview — Tag Pane */
 .tag-pane-tag {
   transition: var(--transition-duration-normal) background, border, border-radius, box-shadow ease-in-out;
 }
 .tag-pane-tag:hover {
-  border-radius: 0.5rem 0.5rem;
+  border-radius: 0.5rem;
   border-left: 1px solid var(--color-shadowy-gold);
   border-right: 1.5px solid var(--color-shadowy-gold);
   box-shadow: 0 -1px 1px var(--color-blue) inset,
               0 -1px 2px var(--color-blue) inset,
-              0 -1px 4px var(--color-blue) inset,
-              0 -1px 2px var(--shadow-primary),
-              0 -1px 4px var(--shadow-primary);
+              0 -1px 4px var(--color-blue) inset;
 }
 /* Preview, Publish — Embeds */
 .markdown-embed {
@@ -900,12 +910,6 @@ ol ol ol ol ol ol li::marker {
   display: none;
 }
 /* Preview, Publish — Popovers */
-/* .popover {
-  background: transparent;
-  border: none;
-  box-shadow: none;
-  overflow: visible;
-} */
 .popover,
 .popover.hover-popover {
   background-color: var(--background-secondary);
@@ -1788,11 +1792,6 @@ span.cm-formatting-quote-6,
 .workspace-leaf-resize-handle:hover {
   background: var(--color-magic-gold);
 }
-/* .workspace-split.mod-vertical > * > .workspace-leaf-resize-handle,
-.workspace-split.mod-left-split > .workspace-leaf-resize-handle,
-.workspace-split.mod-right-split > .workspace-leaf-resize-handle {
-  width: 2px;
-} */
 
 /* 11 Animations */
 @keyframes activeline-r1 {

--- a/obsidian.css
+++ b/obsidian.css
@@ -1523,18 +1523,39 @@ span.cm-formatting-quote-6,
   background: var(--text-strike);
 }
 /* Edit — Links */
+.markdown-source-view.mod-cm6.is-live-preview .cm-line .is-unresolved {
+  opacity: 1;
+}
 .markdown-source-view.mod-cm6.is-live-preview .cm-line .cm-hmd-internal-link .cm-underline,
 .markdown-source-view.mod-cm6.is-live-preview .cm-line .cm-link .cm-underline,
 .markdown-source-view.mod-cm6.is-live-preview .cm-line .cm-url {
   border-radius: 0.25rem;
   text-decoration: none;
 }
-.markdown-source-view.mod-cm6.is-live-preview .cm-line:not(.cm-active) .cm-hmd-internal-link .cm-underline {
-  border-bottom: 1px solid var(--color-magic-gold);
+.markdown-source-view.mod-cm6.is-live-preview .cm-line:not(.cm-active) > .is-unresolved > .cm-hmd-internal-link .cm-underline,
+.markdown-source-view.mod-cm6.is-live-preview .cm-line:not(.cm-active) > .cm-hmd-internal-link .cm-underline {
+  border-bottom: 1px solid var(--link-internal-color);
+}
+.markdown-source-view.mod-cm6.is-live-preview .cm-line.cm-active > .is-unresolved > .cm-hmd-internal-link .cm-underline {
+  color: var(--text-muted);
+  -webkit-text-stroke-color: var(--link-internal-unresolved-color);
+}
+.markdown-source-view.mod-cm6 .cm-line:not(.cm-active) > .is-unresolved > .cm-hmd-internal-link .cm-underline,
+.markdown-source-view.mod-cm6 .cm-line.cm-active > .is-unresolved > .cm-hmd-internal-link .cm-underline,
+.markdown-source-view.mod-cm6.is-live-preview .cm-line:not(.cm-active) > .is-unresolved > .cm-hmd-internal-link .cm-underline,
+.markdown-source-view.mod-cm6.is-live-preview .cm-line.cm-active > .is-unresolved > .cm-comment.cm-hmd-internal-link .cm-underline {
+  color: var(--text-faint);
+  transition: var(--transition-duration-normal) color ease-in-out;
+}
+.markdown-source-view.mod-cm6 .cm-line:not(.cm-active) > .is-unresolved > .cm-hmd-internal-link .cm-underline:hover,
+.markdown-source-view.mod-cm6 .cm-line.cm-active > .is-unresolved > .cm-hmd-internal-link .cm-underline:hover,
+.markdown-source-view.mod-cm6.is-live-preview .cm-line:not(.cm-active) > .is-unresolved > .cm-hmd-internal-link .cm-underline:hover,
+.markdown-source-view.mod-cm6.is-live-preview .cm-line.cm-active > .is-unresolved > .cm-comment.cm-hmd-internal-link .cm-underline:hover {
+  color: var(--link-internal-unresolved-color);
 }
 .markdown-source-view.mod-cm6.is-live-preview .cm-line:not(.cm-active) .cm-link .cm-underline,
 .markdown-source-view.mod-cm6.is-live-preview .cm-line:not(.cm-active) .cm-url {
-  border-top: 1px solid var(--color-shadowy-gold);
+  border-top: 1px solid var(--link-internal-unresolved-color);
 }
 .markdown-source-view.mod-cm6 .external-link {
   display: none;
@@ -1550,7 +1571,7 @@ span.cm-formatting-quote-6,
 .cm-s-obsidian span.cm-formatting-link {
   color: var(--text-normal);
   text-decoration: none;
-  transition: 0.25s color ease-in-out;
+  transition: var(--transition-duration-normal) color ease-in-out;
 }
 .cm-s-obsidian span.cm-url:hover,
 .cm-s-obsidian span.cm-link:hover,
@@ -1663,7 +1684,6 @@ span.cm-formatting-quote-6,
 .markdown-source-view.mod-cm6 .cm-comment,
 .cm-s-obsidian span.cm-comment {
   color: var(--text-muted);
-
 }
 
 /* 11 Animations */

--- a/obsidian.css
+++ b/obsidian.css
@@ -112,6 +112,7 @@
   --transition-duration-instant: 0.05s;
   --transition-duration-fast: 0.15s;
   --transition-duration-normal: 0.25s;
+  --transition-duration-slow: 1s;
 }
 
 /**
@@ -809,16 +810,23 @@ ol ol ol ol ol ol li::marker {
                0 -1px 2px var(--color-teal);
 }
 /* Preview, Publish — File Tree */
+.nav-folder-title[data-path="/"] .nav-folder-title-content {
+  color: var(--color-magic-gold);
+}
 .tree-item,
 .nav-file-title,
 .nav-folder-title {
-  transition: var(--transition-duration-normal) border, border-radius, background, box-shadow ease-in-out;
+  border: none;
+  border-left: 2px solid var(--color-shadowy-gold);
+  border-right: 2.5px solid var(--color-shadowy-gold);
+  border-radius: 0px;
+  transition: var(--transition-duration-normal) border-radius, background, box-shadow ease-in-out;
 }
 .nav-files-container .tree-item:hover,
 .nav-files-container .nav-file-title:hover {
   border-radius: 0.5rem 0.5rem;
-  border-left: 1px solid var(--color-shadowy-gold);
-  border-right: 1.5px solid var(--color-shadowy-gold);
+  border-left: 2px solid var(--color-shadowy-gold);
+  border-right: 2.5px solid var(--color-shadowy-gold);
   box-shadow: 0 -1px 1px var(--color-green) inset,
               0 -1px 2px var(--color-green) inset,
               0 -1px 4px var(--color-green) inset,
@@ -827,8 +835,8 @@ ol ol ol ol ol ol li::marker {
 }
 .nav-files-container .nav-folder-title:hover {
   border-radius: 0.5rem 0.5rem;
-  border-left: 1px solid var(--color-shadowy-gold);
-  border-right: 1.5px solid var(--color-shadowy-gold);
+  border-left: 2px solid var(--color-shadowy-gold);
+  border-right: 2.5px solid var(--color-shadowy-gold);
   box-shadow: 0 -1px 1px var(--color-teal) inset,
               0 -1px 2px var(--color-teal) inset,
               0 -1px 4px var(--color-teal) inset,
@@ -838,13 +846,18 @@ ol ol ol ol ol ol li::marker {
 .nav-files-container .tree-item.mod-active,
 .nav-files-container .nav-file-title.is-active {
   border-radius: 0.5rem 0.5rem;
-  border-left: 1px solid var(--color-magic-gold);
-  border-right: 1.5px solid var(--color-magic-gold);
+  border-left: 2px solid var(--color-magic-gold);
+  border-right: 2.5px solid var(--color-magic-gold);
   box-shadow: 0 -1px 1px var(--color-purple-3) inset,
               0 -1px 2px var(--color-purple-3) inset,
               0 -1px 4px var(--color-purple-3) inset,
               0 -1px 2px var(--shadow-primary),
               0 -1px 4px var(--shadow-primary);
+  transition: var(--transition-duration-normal) border-radius ease-in-out;
+}
+.nav-files-container .tree-item.mod-active:hover,
+.nav-files-container .nav-file-title.is-active:hover {
+  border-radius: 0.75rem 0.75rem;
 }
 /* Preview — Tag Pane */
 .tag-pane-tag {
@@ -864,6 +877,27 @@ ol ol ol ol ol ol li::marker {
 .markdown-embed {
   border-top: none;
   border-bottom: none;
+}
+/* bare embeds */
+.markdown-preview-view.bare-embeds .markdown-embed-content {
+  max-height: unset;
+}
+.markdown-preview-view.bare-embeds .markdown-embed-title {
+  display: none;
+}
+.markdown-preview-view.bare-embeds .markdown-embed-content h1::before {
+  left: calc(var(--editor-font-size) * -1);
+}
+.markdown-preview-view.bare-embeds .markdown-embed .markdown-preview-view {
+  overflow: hidden;
+}
+/* keep titles in bare embeds */
+.markdown-preview-view.bare-embeds.keep-embed-titles .markdown-embed-title {
+  display: block;
+}
+/* hide embeds in embeds */
+.markdown-preview-view.hide-secondary-embeds .markdown-embed .markdown-embed {
+  display: none;
 }
 /* Preview, Publish — Popovers */
 /* .popover {
@@ -989,6 +1023,19 @@ ol ol ol ol ol ol li::marker {
   .markdown-preview-view blockquote {
     color: var(--color-grey-00);
   }
+  .markdown-preview-view .markdown-embed-content {
+    max-height: unset;
+    overflow: hidden;
+    margin-right: 0;
+  }
+  .print .markdown-embed .markdown-preview-view {
+    overflow: hidden;
+    /* width: 90%; */
+  }
+  /* remove embeds from embeds */
+  .markdown-preview-view .markdown-embed .markdown-embed {
+    display: none;
+  }
 }
 /* 9 Settings */
 button,
@@ -1000,6 +1047,11 @@ input,
   font-family: var(--default-font);
 }
 /* 10 Edit */
+/* Increase letter spacing for edit/wysiwyg modes */
+.markdown-source-view,
+.markdown-source-view.mod-cm6 {
+  letter-spacing: 1.5px;
+}
 /* Edit — Metadata */
 .cm-hmd-frontmatter.cm-overlay.cm-spell-error {
   background-image: none;
@@ -1717,6 +1769,30 @@ span.cm-formatting-quote-6,
 .theme-light .graph-view.color-fill-attachment {
   color: var(--color-teal);
 }
+/* Left Ribbon */
+.workspace-ribbon-collapse-btn {
+  margin-top: 0;
+  padding: 7.5px 6px 10px;
+}
+.side-dock-ribbon-action {
+  padding: 0 0 10px 0;
+}
+.side-dock-settings {
+  margin-bottom: 0;
+}
+/* Workspace resize handles */
+.workspace-leaf-resize-handle {
+  background: var(--color-grey-00);
+  transition: background var(--transition-duration-fast) ease-in-out;
+}
+.workspace-leaf-resize-handle:hover {
+  background: var(--color-magic-gold);
+}
+/* .workspace-split.mod-vertical > * > .workspace-leaf-resize-handle,
+.workspace-split.mod-left-split > .workspace-leaf-resize-handle,
+.workspace-split.mod-right-split > .workspace-leaf-resize-handle {
+  width: 2px;
+} */
 
 /* 11 Animations */
 @keyframes activeline-r1 {

--- a/obsidian.css
+++ b/obsidian.css
@@ -1685,6 +1685,38 @@ span.cm-formatting-quote-6,
 .cm-s-obsidian span.cm-comment {
   color: var(--text-muted);
 }
+/* Graph */
+.graph-view.color-line-highlight {
+  color: var(--color-purple-3);
+}
+.graph-view.color-fill-highlight {
+  color: var(--color-purple-1);
+}
+.graph-view.color-circle {
+  color: var(--color-magic-gold);
+}
+.graph-view.color-fill-unresolved {
+  color: var(--shadow-primary);
+  opacity: 0.7;
+}
+.graph-view.color-fill {
+  color: var(--color-magic-gold);
+}
+.graph-view.color-fill-focused {
+  color: var(--color-hot-pink);
+}
+.graph-view.color-arrow {
+  color: var(--color-purple-3);
+  opacity: 0.8;
+}
+.theme-dark .graph-view.color-fill-tag,
+.theme-light .graph-view.color-fill-tag {
+  color: var(--color-green);
+}
+.theme-dark .graph-view.color-fill-attachment,
+.theme-light .graph-view.color-fill-attachment {
+  color: var(--color-teal);
+}
 
 /* 11 Animations */
 @keyframes activeline-r1 {

--- a/publish.css
+++ b/publish.css
@@ -1,5 +1,5 @@
 /**
- Wyrd v0.2.0
+ Wyrd v0.3.0
   A purple-hued, low-contrast, dual-mode theme
     created by Curio Heart for [Obsidian.md](https://obsidian.md/)
   
@@ -9,7 +9,10 @@
  */
 
 /**
-  1 Fonts
+  1 Front matter
+ */
+/**
+  1.1 Fonts
  */
 /* Preview: Neucha */
 @import url('https://fonts.googleapis.com/css2?family=Neucha&display=swap');
@@ -20,19 +23,22 @@
 @import url('https://fonts.googleapis.com/css2?family=Birthstone&display=swap');
 
 /**
-  2 Custom list counters
+  1.2 Custom list counters
  */
- @counter-style wyrd {
+@counter-style wyrd {
   system: cyclic;
   symbols: "\2192";
   suffix: " ";
 }
 
 /**
-  3 Core Defaults
+  2 Default Settings
+ */
+/**
+  2.1 Core Defaults
  */
 :root {
-  /* 3.1 Fonts */
+  /* 2.1.1 Fonts */
   --default-font: Neucha, Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif;
   --font-heading: var(--default-font);
   --mermaid-font: var(--default-font);
@@ -42,7 +48,7 @@
   /* Only active within Publish spaces; body styling overrides this within Obsidian */
   --editor-font-size: 16px;
 
-  /* 3.2 Color Palette */
+  /* 2.1.2 Color Palette */
   --color-blacker: hsl(270, 10%, 5%);
   --color-blacker-hsl: 270, 10%, 5%;
   --color-black: hsl(270, 10%, 10%);
@@ -93,7 +99,7 @@
   --color-bold: hsl(12, 65%, 62%);
   --color-italic: hsl(346, 64%, 57%);
 
-  /* 3.3 Various Settings */
+  /* 2.1.3 Various Settings */
   --text-stroke-width: 0.2px;
   --link-footlink-stroke-width: 0.1px;
   --heading-stroke-width: 0.01px;
@@ -109,7 +115,10 @@
 }
 
 /**
-  4 Dark Mode defaults
+  2.2 Theme Modes
+ */
+/**
+  2.2.1 Dark Mode defaults
  */
 .theme-dark {
   --background-primary: var(--color-grey-03);
@@ -127,7 +136,7 @@
 }
 
 /**
-  5 Light Mode defaults
+  2.2.2 Light Mode defaults
 */
 .theme-light {
   --background-primary: var(--color-grey-10);
@@ -145,7 +154,7 @@
 }
 
 /**
-  6 Mixed defaults
+  2.2.3 Mixed defaults
  */
 .theme-dark,
 .theme-light {
@@ -176,13 +185,13 @@
   --scrollbar-thumb-bg: hsla(var(--scrollbar-hsl), 0.1);
   --highlight-mix-blend-mode: lighten;
 }
-/* 7 Publish */
+/* 3 Publish */
 .published-container {
   font-size: var(--editor-font-size);
   position: relative;
 }
-/* 8 Preview */
-/* Preview — Headings */
+/* 4 Preview */
+/* 4.1 Preview — Headings */
 .markdown-preview-view h1,
 .markdown-preview-view h2,
 .markdown-preview-view h3,
@@ -363,56 +372,56 @@
   top: calc(var(--editor-font-size) / 9);
   z-index: -1;
 }
-/* Preview — Text */
-/* Preview — Text — Italic */
+/* 4.2 Preview — Text */
+/* 4.2.1 Preview — Text — Italic */
 em,
 .markdown-preview-view em {
   -webkit-text-stroke-color: var(--color-italic);
   -webkit-text-stroke-width: 0.5px;
 }
-/* Preview — Text — Bold */
+/* 4.2.2 Preview — Text — Bold */
 strong,
 .markdown-preview-view strong {
   -webkit-text-fill-color: var(--color-bold);
   -webkit-text-stroke-width: 0.05px;
 }
-/* Preview — Text — Underline */
+/* 4.2.3 Preview — Text — Underline */
 em > em,
 .markdown-preview-view em > em {
   font-style: normal;
-  text-decoration: underline 0.15rem var(--color-pale-purple);
+  text-decoration: underline calc(var(--editor-font-size) / 8) var(--color-pale-purple);
   -webkit-text-stroke-width: 0;
 }
 strong > strong,
 .markdown-preview-view strong > strong {
   font-weight: normal;
-  text-decoration: underline 0.15rem var(--color-pale-purple);
+  text-decoration: underline calc(var(--editor-font-size) / 8) var(--color-pale-purple);
   -webkit-text-fill-color: var(--text-normal);
   -webkit-text-stroke-width: 0;
 }
-/* Preview — Text — Bold + Italic */
+/* 4.2.4 Preview — Text — Bold + Italic */
 em > strong,
 strong > em,
 .markdown-preview-view em > strong,
 .markdown-preview-view strong > em {
   -webkit-text-stroke-width: 0.05px;
 }
-/* Preview — Text — Italic + Underline */
+/* 4.2.5 Preview — Text — Italic + Underline */
 em > strong > strong,
 .markdown-preview-view em > strong > strong {
-  text-decoration: underline 0.15rem var(--color-pale-purple);
+  text-decoration: underline calc(var(--editor-font-size) / 8) var(--color-pale-purple);
   -webkit-text-stroke-width: 0.5px;
 }
-/* Preview — Text — Bold + Underline */
+/* 4.2.6 Preview — Text — Bold + Underline */
 strong > em > em,
 .markdown-preview-view strong > em > em {
   font-weight: bold;
-  text-decoration: underline 0.15rem var(--color-pale-purple);
+  text-decoration: underline calc(var(--editor-font-size) / 8) var(--color-pale-purple);
   -webkit-text-fill-color: var(--text-bold);
   -webkit-text-stroke-color: var(--text-normal);
   -webkit-text-stroke-width: 0.05px;
 }
-/* Preview — Text — Visual Redaction */
+/* 4.2.7 Preview — Text — Visual Redaction */
 strong > em > strong > em,
 .markdown-preview-view strong > em > strong > em {
   background-color: hsl(var(--color-blacker-hsl));
@@ -423,7 +432,7 @@ strong > em > strong > em,
   -webkit-text-stroke-color: transparent;
 }
 /* em em strong strong {} */
-/* Preview — Text — Highlight */
+/* 4.2.8 Preview — Text — Highlight */
 mark,
 .markdown-preview-view mark {
   color: var(--text-normal);
@@ -440,7 +449,7 @@ mark:hover,
   filter: drop-shadow(0 -1px 0.15rem var(--color-cyan-desat));
   text-shadow: 0 -1px 1.5px var(--shadow-primary);
 }
-/* Preview — Text — Strikethrough */
+/* 4.2.9 Preview — Text — Strikethrough */
 del,
 .markdown-preview-view del {
   color: var(--text-strike);
@@ -451,7 +460,40 @@ del:hover,
 .markdown-preview-view del:hover {
   color: var(--text-muted);
 }
-/* Preview — Text — Blur */
+li del,
+li del .internal-link,
+li del .internal-link.is-unresolved,
+li del .external-link,
+.markdown-preview-view li del,
+.markdown-preview-view li del .internal-link,
+.markdown-preview-view li del .internal-link.is-unresolved,
+.markdown-preview-view li del .external-link {
+  color: var(--text-strike);
+  -webkit-text-stroke-color: transparent;
+  transition: var(--transition-duration-normal) color, -webkit-text-stroke-color ease-in-out;
+}
+.markdown-preview-view li del:hover .internal-link {
+  color: var(--text-muted);
+  -webkit-text-stroke-color: var(--link-internal-color);
+}
+.markdown-preview-view li del:hover .internal-link.is-unresolved {
+  color: var(--text-muted);
+  -webkit-text-stroke-color: var(--link-internal-unresolved-color);
+}
+.markdown-preview-view li del:hover .external-link {
+  color: var(--text-muted);
+  -webkit-text-stroke-color: var(--link-external-color);
+}
+.markdown-preview-view li del:hover .internal-link:hover {
+  color: var(--link-internal-color);
+}
+.markdown-preview-view li del:hover .internal-link.is-unresolved:hover {
+  color: var(--link-internal-unresolved-color);
+}
+.markdown-preview-view li del:hover .external-link:hover {
+  color: var(--link-external-color);
+}
+/* 4.2.10 Preview — Text — Blur */
 del > mark,
 .markdown-preview-view del > mark {
   color: var(--text-faint);
@@ -482,18 +524,20 @@ h5 > del > mark:hover, .markdown-preview-view h5 > del > mark:hover,
 h6 > del > mark:hover, .markdown-preview-view h6 > del > mark:hover {
   filter: blur(0) drop-shadow(0 0 0.5rem);
 }
-/* Preview — Text — Blockquotes */
+/* 4.2.11 Preview — Text — Blockquotes */
 blockquote,
 .markdown-preview-view blockquote {
+  background-color: var(--background-secondary);
   border: 0;
   border-radius: 0.5rem;
   border-left: 5px solid var(--color-purple-3);
   border-right: 1px solid var(--color-purple-3);
   box-shadow: 0 -1px 1px var(--color-magic-gold) inset,
               0 -1px 2px var(--color-magic-gold) inset;
+  color: var(--text-muted);
   margin-inline-start: 5px;
   margin-inline-end: 5px;
-  transition: var(--transition-duration-instant) box-shadow ease-in-out;
+  transition: var(--transition-duration-instant) box-shadow, color ease-in-out;
 }
 blockquote:hover,
 .markdown-preview-view blockquote:hover {
@@ -509,6 +553,7 @@ blockquote:hover,
               0 -1px 2px var(--color-shadowy-gold),
               0 -1px 4px var(--color-shadowy-gold),
               0 -1px 8px var(--color-shadowy-gold);
+  color: var(--text-normal);
 }
 blockquote blockquote,
 .markdown-preview-view blockquote blockquote {
@@ -530,7 +575,7 @@ blockquote blockquote blockquote blockquote blockquote blockquote,
 .markdown-preview-view blockquote blockquote blockquote blockquote blockquote blockquote {
   border-color: var(--color-cyan-desat);
 }
-/* Preview — Lists */
+/* 4.3 Preview — Lists */
 ul, ol {
   padding-inline-start: 15px;
 }
@@ -543,7 +588,7 @@ ol li p {
   position: relative;
   text-align: right;
 }
-/* Preview — Lists — Unordered */
+/* 4.3.1 Preview — Lists — Unordered */
 ul,
 ul ul,
 ul ul ul,
@@ -583,7 +628,7 @@ ul ul ul ul ul li::marker {
 ul ul ul ul ul ul li::marker {
   color: var(--color-cyan-desat);
 }
-/* Preview — Lists — Ordered */
+/* 4.3.2 Preview — Lists — Ordered */
 ol li::marker {
   color: var(--color-purple-3);
 }
@@ -602,7 +647,19 @@ ol ol ol ol ol li::marker {
 ol ol ol ol ol ol li::marker {
   color: var(--color-cyan-desat);
 }
-/* Preview — Links */
+/* 4.3.3 Preview — Task Lists */
+.markdown-preview-view ul > li.task-list-item.is-checked,
+.markdown-preview-view ul > li > ul > li.task-list-item.is-checked,
+.markdown-preview-view ul > li.task-list-item > ul > li.task-list-item.is-checked {
+  text-decoration: none;
+  color: var(--text-faint);
+}
+.markdown-preview-view ul > li.task-list-item.is-checked > ul > li,
+.markdown-preview-view.mod-cm6 ul > li.task-list-item.is-checked > ul > li {
+  color: var(--text-normal);
+}
+/* 4.4 Preview — Links */
+/* 4.4.1 Preview — Links — Internal */
 .markdown-preview-view .internal-link {
   color: var(--color-normal);
   border-bottom: 1px solid var(--color-magic-gold);
@@ -614,6 +671,7 @@ ol ol ol ol ol ol li::marker {
 .markdown-preview-view .internal-link:hover {
   color: var(--link-internal-color);
 }
+/* 4.4.2 Preview — Links — Internal, unresolved */
 .markdown-preview-view .internal-link.is-unresolved {
   color: var(--text-muted);
   opacity: 1;
@@ -622,10 +680,13 @@ ol ol ol ol ol ol li::marker {
 .markdown-preview-view .internal-link.is-unresolved:hover {
   color: var(--link-internal-unresolved-color);
 }
+/* 4.4.3 Preview — Links — External */
 .external-link {
+  background-image: none;
   border-top: 1px solid var(--color-shadowy-gold);
   border-radius: 0.25rem;
   color: var(--text-normal);
+  padding-right: 0;
   -webkit-text-stroke: var(--text-stroke-width) var(--link-external-color);
   text-decoration-line: none;
   transition: var(--transition-duration-normal) color ease-in-out;
@@ -633,6 +694,7 @@ ol ol ol ol ol ol li::marker {
 .external-link:hover {
   color: var(--link-external-color);
 }
+/* 4.4.4 Preview — Links — Footlinks */
 .footnote-link,
 .footnote-ref {
   border-radius: 0.25rem;
@@ -647,6 +709,7 @@ ol ol ol ol ol ol li::marker {
 .footnote-ref:hover {
   color: var(--link-footlink-color);
 }
+/* 4.4.5 Preview — Links — Links in headers */
 .markdown-preview-view h1 > .external-link,
 .markdown-preview-view h2 > .external-link,
 .markdown-preview-view h3 > .external-link,
@@ -671,6 +734,7 @@ ol ol ol ol ol ol li::marker {
   color: var(--link-external-color);
 }
 /* Preview — Horizontal Rules */
+.markdown-source-view.mod-cm6 .hr hr,
 .markdown-preview-view hr {
   border: none;
   background: linear-gradient(90deg, transparent, var(--color-shadowy-gold) 20%, var(--color-magic-gold), var(--color-shadowy-gold) 80%, transparent 100%);
@@ -795,6 +859,39 @@ ol ol ol ol ol ol li::marker {
               0 -1px 4px var(--color-blue) inset,
               0 -1px 2px var(--shadow-primary),
               0 -1px 4px var(--shadow-primary);
+}
+/* Preview, Publish — Embeds */
+.markdown-embed {
+  border-top: none;
+  border-bottom: none;
+}
+/* Preview, Publish — Popovers */
+/* .popover {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  overflow: visible;
+} */
+.popover,
+.popover.hover-popover {
+  background-color: var(--background-secondary);
+  border-left: 1px solid var(--shadow-primary);
+  border-radius: 1.5rem;
+  border-right: 1px solid var(--shadow-primary);
+  box-shadow: 0 -1px 2px var(--shadow-primary),
+              0 -1px 4px var(--shadow-primary),
+              0 -1px 8px var(--shadow-primary),
+              0 -1px 16px var(--shadow-primary);
+}
+.popover .markdown-preview-view,
+.popover.hover-popover .markdown-preview-view {
+  background-color: var(--background-primary);
+  border-radius: 1.5rem;
+}
+.popover.hover-popover .thought {
+  border-bottom: 1px solid var(--color-purple-3);
+  border-left: 3px solid var(--color-purple-3);
+  border-top: 1px solid var(--color-purple-3);
 }
 /* Publish */
 /* Publish — Header */


### PR DESCRIPTION
# Wyrd: A Hekkin' Big v0.3

Happy Holidays, everyone! This update brings a **lot** of styling support that was previously lacking!

## Live Preview is here!

Naturally, this was a big thing to get done—and I'm still working on it! Because my theme takes advantage of all _kinds_ of weird quirks, not everything is working quite right yet, but much of it should be rendering as expected!

One unique feature to Live Preview (for now!) is how task lists are rendered—this is only because I haven't taken aim at the reader view with it yet! This will be coming very, _very_ soon as I continue working on the theme!

## Print Styling?!

Yep, that's right—Wyrd now hits `@media print` for when you hit that `Print to PDF` button! I'm trying to focus Print's styling to be respectful of the amount of ink used _without_ sacrificing any of Wyrd's unusual design, and so have taken some liberties with re-imagining some parts—particularly the headings.

## File Explorer

While the Explorer was already styled, I felt like it wasn't quite where I wanted it to be. It had part of the _look_ I wanted, but lacked much of the **feel**—but no more! With unique visual effects for both folders and files based on state, I think you'll find the new File Explorer look a bit more animated~

## Graph View

The graph has been updated, too! With new default styles for each graph part, I think we can all celebrate having those pesky mismatched colors replaced with those from the theme itself.

> Note: There's currently an issue where placing the graph in a sidebar will cause unresolved nodes to appear invisible; this is due to the color for both the workspace leaves and unresolved files being identical within the theme. While unintentionally done, it _does_ look pretty cool when there's a bunch of files pointing to the same nonexistent file.

## Other Updates

While those are the _major_ updates, a few other things have been done lately, too!

### Better Embed Support

While regular embeds still look out of place, popovers have received some love for better styling.

However, let it not be said that they've received _little_ love: both popovers and embeds have some custom `cssclass`es that can be applied for improved appearances!

- **Popovers**
  - `thought` adds a purple border to most of the popover. This is not visible when a note is embedded right now.
- **Embeds**
  - `bare-embeds` makes makes embeds visually indistinguishable from the rest of the note, including removing that pesky title
    - Want that title anyways? Add `keep-embed-titles` to prevent them from being hidden!
  - `hide-secondary-embeds` exists to help limit recursion by preventing embeds within embeds from being rendered

### Ribbon Improvements

That sidebar seemed _far_ too spaced out between icons for my tastes before, so I fixed it! Enjoy a more-condensed sidebar _without_ snippets to fix its! … it.

Sorry, I… got a bit carried away there. 😅 

## Issues?

Because of how many quirks I take advantage of, there's **_definitely_** some things that I've missed or still need to fix! Among them:

- Live Preview headings aren't aligned with their backgrounds
- Code styles have not been changed to match the theme
- Plain embeds have not been restyled for Live Preview
- Active line indicator needs to be moved outside of the text

### Additional Notes

Some of the more unusual styles that are visible in Reading mode are currently not available within Live Preview, like underlines and redactions. Unfortunately, this isn't anything I can do something about; it's caused by differences in behavior between the parsers used for Live Preview and Reading modes, and is out of my hands.

-- -- --

If you find any other bugs, problem areas, or missed styles, please file an issue! 💜