### PR TITLE
Fix headings in Live Preview

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -1,5 +1,5 @@
 /**
- Wyrd v0.3.1
+ Wyrd v0.3.2
   A purple-hued, low-contrast, dual-mode theme
     created by Curio Heart for [Obsidian.md](https://obsidian.md/)
   

--- a/obsidian.css
+++ b/obsidian.css
@@ -1109,6 +1109,20 @@ input,
 .cm-s-obsidian .cm-formatting-header {
   padding-left: 0.5rem;
 }
+.markdown-source-view.mod-cm6.is-live-preview .HyperMD-header {
+  left: 1.5rem;
+}
+.markdown-source-view.mod-cm6 .cm-active.HyperMD-header {
+  left: unset;
+}
+.markdown-source-view.mod-cm6 .HyperMD-header-1::before,
+.markdown-source-view.mod-cm6 .HyperMD-header-2::before,
+.markdown-source-view.mod-cm6 .HyperMD-header-3::before,
+.markdown-source-view.mod-cm6 .HyperMD-header-4::before,
+.markdown-source-view.mod-cm6 .HyperMD-header-5::before,
+.markdown-source-view.mod-cm6 .HyperMD-header-6::before {
+  left: -1.5rem;
+}
 .cm-s-obsidian .HyperMD-header-1 {
   font-size: calc(var(--editor-font-size) * 1.6);
   text-shadow: 0 -1px calc(var(--editor-font-size) / 16) var(--shadow-primary),


### PR DESCRIPTION
Headings will now properly render with text fully over the background when in Live Preview.